### PR TITLE
First commits for an Ansible role to install and configure `systemd-resolved`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,17 +19,17 @@ updates:
       - dependency-name: hashicorp/setup-terraform
       - dependency-name: mxschmitt/action-tmate
       - dependency-name: step-security/harden-runner
-      # # Managed by cisagov/skeleton-ansible-role
-      # - dependency-name: github/codeql-action
+      # Managed by cisagov/skeleton-ansible-role
+      - dependency-name: github/codeql-action
     package-ecosystem: github-actions
     schedule:
       interval: weekly
 
   - directory: /
-    # ignore:
-    #   # Managed by cisagov/skeleton-ansible-role
-    #   - dependency-name: ansible
-    #   - dependency-name: ansible-core
+    ignore:
+      # Managed by cisagov/skeleton-ansible-role
+      - dependency-name: ansible
+      - dependency-name: ansible-core
     package-ecosystem: pip
     schedule:
       interval: weekly

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -158,12 +158,19 @@ repos:
     hooks:
       - id: ansible-lint
         additional_dependencies:
-          # For some reason ansible-lint does not know about the
-          # existence of ansible.posix.mount unless ansible itself is
-          # added as an extra dependency.  I (jsf9k) believe this is
-          # because ansible is not installed when ansible-lint is
-          # installed.
-          - ansible
+          # Per the documentation and the pre-commit hook
+          # configuration, ansible-lint does not know about modules
+          # that live outside of ansible-core.  See these links for
+          # more details:
+          # - https://github.com/ansible/ansible-lint/blob/main/src/ansiblelint/rules/syntax_check.md#syntax-checkunknown-module
+          # - https://github.com/ansible/ansible-lint/blob/ad0157eb38059b02d57458504340209f221e3189/.pre-commit-hooks.yaml#L14-L19
+          #
+          # Since ansible.posix.mount lives inside of the ansible
+          # package itself, we must include that package here.
+          #
+          # Note also that for consistency's sake we pull in the same
+          # version of ansible that is used in requirements-test.txt.
+          - ansible>=8,<10
       # files: molecule/default/playbook.yml
 
   # Terraform hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -157,6 +157,8 @@ repos:
     rev: v24.2.0
     hooks:
       - id: ansible-lint
+        additional_dependencies:
+          - ansible
       # files: molecule/default/playbook.yml
 
   # Terraform hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -158,6 +158,11 @@ repos:
     hooks:
       - id: ansible-lint
         additional_dependencies:
+          # For some reason ansible-lint does not know about the
+          # existence of ansible.posix.mount unless ansible itself is
+          # added as an extra dependency.  I (jsf9k) believe this is
+          # because ansible is not installed when ansible-lint is
+          # installed.
           - ansible
       # files: molecule/default/playbook.yml
 

--- a/README.md
+++ b/README.md
@@ -3,13 +3,15 @@
 [![GitHub Build Status](https://github.com/cisagov/ansible-role-systemd-resolved/workflows/build/badge.svg)](https://github.com/cisagov/ansible-role-systemd-resolved/actions)
 [![CodeQL](https://github.com/cisagov/ansible-role-systemd-resolved/workflows/CodeQL/badge.svg)](https://github.com/cisagov/ansible-role-systemd-resolved/actions/workflows/codeql-analysis.yml)
 
-This is a skeleton project that can be used to quickly get a new
-[cisagov](https://github.com/cisagov) Ansible role GitHub project
-started.  This skeleton project contains
-[licensing information](LICENSE), as well as
-[pre-commit hooks](https://pre-commit.com) and
-[GitHub Actions](https://github.com/features/actions) configurations
-appropriate for an Ansible role.
+This is an Ansible role that installs and configures
+[`systemd-resolved`](https://wiki.archlinux.org/title/systemd-resolved).
+It performs the following actions:
+
+- Installs `systemd-resolved` and ensures that `resolvconf` is not
+  installed.
+- Creates an `/etc/resolv.conf` symlink that results in the
+  `systemd-resolved` stub DNS resolver being used by default for all
+  system DNS lookups.
 
 ## Requirements ##
 
@@ -42,7 +44,7 @@ where `requirements.yml` looks like:
 
 ```yaml
 ---
-- name: skeleton
+- name: systemd_resolved
   src: https://github.com/cisagov/ansible-role-systemd-resolved
 ```
 
@@ -61,17 +63,10 @@ Here's how to use it in a playbook:
   become: true
   become_method: sudo
   tasks:
-    - name: Include skeleton
+    - name: Include systemd-resolved
       ansible.builtin.include_role:
-        name: skeleton
+        name: systemd_resolved
 ```
-
-## New Repositories from a Skeleton ##
-
-Please see our [Project Setup guide](https://github.com/cisagov/development-guide/tree/develop/project_setup)
-for step-by-step instructions on how to start a new repository from
-a skeleton. This will save you time and effort when configuring a
-new repository!
 
 ## Contributing ##
 
@@ -93,4 +88,4 @@ with this waiver of copyright interest.
 
 ## Author Information ##
 
-First Last - <first.last@gwe.cisa.dhs.gov>
+Shane Frasier - <jeremy.frasier@gwe.cisa.dhs.gov>

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -27,8 +27,9 @@ galaxy_info:
         - "2023"
     - name: Debian
       versions:
-        - buster
-        - bullseye
+        # These platforms do not provide systemd-resolved.
+        # - buster
+        # - bullseye
         - bookworm
         - trixie
     - name: Fedora
@@ -38,9 +39,10 @@ galaxy_info:
     - name: Kali
       versions:
         - "2023"
-    - name: Ubuntu
-      versions:
-        - focal
-        - jammy
+    # These platforms do not provide systemd-resolved.
+    # - name: Ubuntu
+    #   versions:
+    #     - focal
+    #     - jammy
   role_name: systemd_resolved
   standalone: true

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,11 +6,13 @@
 # See also cisagov/skeleton-ansible-role#153.
 dependencies: []
 galaxy_info:
-  author: First Last
+  author: Shane Frasier
   company: CISA Cyber Assessments
-  description: Skeleton Ansible role
+  description: Install and configure systemd-resolved
   galaxy_tags:
-    - skeleton
+    - resolved
+    - systemd
+    - systemdresolved
   license: CC0
   # With the release of version 2.10, Ansible finally correctly
   # identifies Kali Linux as being the Kali distribution of the Debian
@@ -40,5 +42,5 @@ galaxy_info:
       versions:
         - focal
         - jammy
-  role_name: skeleton
+  role_name: systemd_resolved
   standalone: true

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -13,24 +13,25 @@ platforms:
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  - cgroupns_mode: host
-    command: /lib/systemd/systemd
-    image: docker.io/geerlingguy/docker-debian10-ansible:latest
-    name: debian10-systemd
-    platform: amd64
-    pre_build_image: true
-    privileged: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  - cgroupns_mode: host
-    command: /lib/systemd/systemd
-    image: docker.io/geerlingguy/docker-debian11-ansible:latest
-    name: debian11-systemd
-    platform: amd64
-    pre_build_image: true
-    privileged: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  # These platforms do not provide systemd-resolved.
+  # - cgroupns_mode: host
+  #   command: /lib/systemd/systemd
+  #   image: docker.io/geerlingguy/docker-debian10-ansible:latest
+  #   name: debian10-systemd
+  #   platform: amd64
+  #   pre_build_image: true
+  #   privileged: true
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  # - cgroupns_mode: host
+  #   command: /lib/systemd/systemd
+  #   image: docker.io/geerlingguy/docker-debian11-ansible:latest
+  #   name: debian11-systemd
+  #   platform: amd64
+  #   pre_build_image: true
+  #   privileged: true
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-debian12-ansible:latest
@@ -76,24 +77,25 @@ platforms:
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  - cgroupns_mode: host
-    command: /lib/systemd/systemd
-    image: docker.io/geerlingguy/docker-ubuntu2004-ansible:latest
-    name: ubuntu-20-systemd
-    platform: amd64
-    pre_build_image: true
-    privileged: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  - cgroupns_mode: host
-    command: /lib/systemd/systemd
-    image: docker.io/geerlingguy/docker-ubuntu2204-ansible:latest
-    name: ubuntu-22-systemd
-    platform: amd64
-    pre_build_image: true
-    privileged: true
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  # These platforms do not provide systemd-resolved.
+  # - cgroupns_mode: host
+  #   command: /lib/systemd/systemd
+  #   image: docker.io/geerlingguy/docker-ubuntu2004-ansible:latest
+  #   name: ubuntu-20-systemd
+  #   platform: amd64
+  #   pre_build_image: true
+  #   privileged: true
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  # - cgroupns_mode: host
+  #   command: /lib/systemd/systemd
+  #   image: docker.io/geerlingguy/docker-ubuntu2204-ansible:latest
+  #   name: ubuntu-22-systemd
+  #   platform: amd64
+  #   pre_build_image: true
+  #   privileged: true
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
 scenario:
   name: default
 verifier:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -1,3 +1,11 @@
 ---
 - name: Import upgrade playbook
   ansible.builtin.import_playbook: upgrade.yml
+
+# Docker bind mounts a file from the host to /etc/resolv.conf.  This
+# is inconvenient for us, since we need to create a symlink at
+# /etc/resolv.conf.  At the same time, we don't want to break DNS.
+# The playbook being imported contains a workaround for this
+# situation.
+- name: Unmount /etc/resolv.conf
+  ansible.builtin.import_playbook: unmount.yml

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -9,3 +9,14 @@
 # situation.
 - name: Unmount /etc/resolv.conf
   ansible.builtin.import_playbook: unmount.yml
+
+# We require dig for one of our Molecule tests
+- name: Install dig
+  hosts: all
+  become: true
+  become_method: ansible.builtin.sudo
+  tasks:
+  - name: Install dig
+    ansible.builtin.package:
+      name:
+        - dnsutils

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -25,9 +25,18 @@ def test_symlink(host):
     """Verify that /etc/resolv.conf is the expected symlink."""
     f = host.file("/etc/resolv.conf")
     assert f.is_symlink, "/etc/resolv.conf is not a symlink."
+
+    if host.system_info.distribution in ["amzn"]:
+        # /run/systemd/resolve/stub-resolv.conf is a symlink to
+        # /run/systemd/resolve/resolv.conf in AL2023, so the
+        # /etc/resolv.conf symlink resolves to the former.
+        symlink_target = "/run/systemd/resolve/resolv.conf"
+    else:
+        symlink_target = "/run/systemd/resolve/stub-resolv.conf"
+
     assert (
-        f.linked_to == "/run/systemd/resolve/stub-resolv.conf"
-    ), "/etc/resolv.conf is not a symlink to /run/systemd/resolve/stub-resolv.conf."
+        f.linked_to == symlink_target
+    ), f"/etc/resolv.conf is not a symlink to {symlink_target}."
 
 
 def test_services(host):

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -32,6 +32,11 @@ def test_symlink(host):
 
 def test_services(host):
     """Verify that the expected services are present."""
-    s = host.service("systemd-resolved.service")
-    assert s.exists, "systemd-resolved.service does not exist."
-    assert s.is_enabled, "systemd-resolved.service is not enabled."
+    s = host.service("systemd-resolved")
+    # This assertion currently fails because of
+    # pytest-dev/pytest-testinfra#757.  Once
+    # pytest-dev/pytest-testinfra#754 has been merged and a new
+    # release is created the following line can be uncommented.
+    # assert s.exists, "systemd-resolved service does not exist."
+    assert s.is_enabled, "systemd-resolved service is not enabled."
+    assert s.is_running, "systemd-resolved service is not running."

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -42,10 +42,12 @@ def test_symlink(host):
 def test_services(host):
     """Verify that the expected services are present."""
     s = host.service("systemd-resolved")
-    # This assertion currently fails because of
+    # TODO - This assertion currently fails because of
     # pytest-dev/pytest-testinfra#757.  Once
     # pytest-dev/pytest-testinfra#754 has been merged and a new
     # release is created the following line can be uncommented.
+    #
+    # See #3 for more details.
     # assert s.exists, "systemd-resolved service does not exist."
     assert s.is_enabled, "systemd-resolved service is not enabled."
     assert s.is_running, "systemd-resolved service is not running."

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -31,7 +31,7 @@ def test_symlink(host):
     if host.system_info.distribution in ["amzn"]:
         # /run/systemd/resolve/stub-resolv.conf is a symlink to
         # /run/systemd/resolve/resolv.conf in AL2023, so the
-        # /etc/resolv.conf symlink resolves to the former.
+        # /etc/resolv.conf symlink resolves to the latter.
         symlink_target = "/run/systemd/resolve/resolv.conf"
     else:
         symlink_target = "/run/systemd/resolve/stub-resolv.conf"

--- a/molecule/default/unmount.yml
+++ b/molecule/default/unmount.yml
@@ -4,23 +4,30 @@
   become: true
   become_method: ansible.builtin.sudo
   tasks:
-    - name: Copy /etc/resolv.conf to /tmp
+    - name: >-
+        Grab the current owner, group, and mode for the existing
+        /etc/resolv.conf
+      ansible.builtin.stat:
+        follow: true
+        path: /etc/resolv.conf
+      register: resolv_conf
+    - name: Copy /etc/resolv.conf to /tmp, preserving owner, group, and mode
       ansible.builtin.copy:
         dest: /tmp/resolv.conf
-        group: root
-        mode: u=rw,g=r,o=r
-        owner: root
+        group: "{{ resolv_conf.stat.gid }}"
+        mode: "{{ resolv_conf.stat.mode }}"
+        owner: "{{ resolv_conf.stat.uid }}"
         remote_src: true
         src: /etc/resolv.conf
     - name: Unmount /etc/resolv.conf
       ansible.posix.mount:
         path: /etc/resolv.conf
         state: unmounted
-    - name: Copy /tmp/resolv.conf to /etc
+    - name: Copy /tmp/resolv.conf to /etc, preserving owner, group, and mode
       ansible.builtin.copy:
         dest: /etc/resolv.conf
-        group: root
-        mode: u=rw,g=r,o=r
-        owner: root
+        group: "{{ resolv_conf.stat.gid }}"
+        mode: "{{ resolv_conf.stat.mode }}"
+        owner: "{{ resolv_conf.stat.uid }}"
         remote_src: true
         src: /tmp/resolv.conf

--- a/molecule/default/unmount.yml
+++ b/molecule/default/unmount.yml
@@ -11,6 +11,7 @@
         follow: true
         path: /etc/resolv.conf
       register: resolv_conf
+
     - name: Copy /etc/resolv.conf to /tmp, preserving owner, group, and mode
       ansible.builtin.copy:
         dest: /tmp/resolv.conf
@@ -19,10 +20,12 @@
         owner: "{{ resolv_conf.stat.uid }}"
         remote_src: true
         src: /etc/resolv.conf
+
     - name: Unmount /etc/resolv.conf
       ansible.posix.mount:
         path: /etc/resolv.conf
         state: unmounted
+
     - name: Copy /tmp/resolv.conf to /etc, preserving owner, group, and mode
       ansible.builtin.copy:
         dest: /etc/resolv.conf

--- a/molecule/default/unmount.yml
+++ b/molecule/default/unmount.yml
@@ -1,0 +1,26 @@
+---
+- name: Unmount /etc/resolv.conf
+  hosts: all
+  become: true
+  become_method: ansible.builtin.sudo
+  tasks:
+    - name: Copy /etc/resolv.conf to /tmp
+      ansible.builtin.copy:
+        dest: /tmp/resolv.conf
+        group: root
+        mode: u=rw,g=r,o=r
+        owner: root
+        remote_src: true
+        src: /etc/resolv.conf
+    - name: Unmount /etc/resolv.conf
+      ansible.posix.mount:
+        path: /etc/resolv.conf
+        state: unmounted
+    - name: Copy /tmp/resolv.conf to /etc
+      ansible.builtin.copy:
+        dest: /etc/resolv.conf
+        group: root
+        mode: u=rw,g=r,o=r
+        owner: root
+        remote_src: true
+        src: /tmp/resolv.conf

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,12 +21,11 @@
 
 - name: Create /etc/resolv.conf symlink
   ansible.builtin.file:
+    # Do not apply any group, owner, or mode changes to src.
+    follow: false
     # If a file is already present at /etc/resolv.conf then just
     # delete it.
     force: true
-    group: root
-    mode: u=rw,g=r,o=r
-    owner: root
     path: /etc/resolv.conf
     src: /run/systemd/resolve/stub-resolv.conf
     state: link

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,15 @@
     name:
       - systemd-resolved
 
+- name: Enable and start systemd-resolved
+  ansible.builtin.service:
+    enabled: true
+    name: systemd-resolved.service
+    # We must start the service to populate the files in
+    # /run/systemd/resolve/, which we need when we create a symlink
+    # below.
+    state: started
+
 - name: Ensure resolvconf is not installed
   ansible.builtin.package:
     name:
@@ -21,8 +30,3 @@
     path: /etc/resolv.conf
     src: /run/systemd/resolve/stub-resolv.conf
     state: link
-
-- name: Enable systemd-resolved
-  ansible.builtin.service:
-    enabled: true
-    name: systemd-resolved.service

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,21 @@
 
 - name: Create /etc/resolv.conf symlink
   ansible.builtin.file:
-    # Do not apply any group, owner, or mode changes to src.
+    # Note that group, owner, and mode can modify src when follow=true
+    # and state=link are used:
+    # https://docs.ansible.com/ansible/latest/collections/ansible/builtin/file_module.html#parameter-follow
+    #
+    # In fact, I found this to be exactly the case when testing.  In
+    # other words, if I set follow=true (or left it as the default)
+    # without specifying group, owner, or mode then the group and
+    # owner of src (i.e., /run/systemd/resolve/stub-resolv.conf) would
+    # both be changed from systemd-resolved to root.
+    #
+    # In this case we definitely _do not_ want to modify the group,
+    # owner, or mode of src, and we do not need to follow any
+    # filesystem links to arrive at /etc/resolv.conf, so we simply
+    # override the default and set follow equal to false.  This will
+    # ensure that no group, owner, or mode changes are applied to src.
     follow: false
     # If a file is already present at /etc/resolv.conf then just
     # delete it.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,28 @@
 ---
-# tasks file for skeleton
+- name: Install systemd-resolved
+  ansible.builtin.package:
+    name:
+      - systemd-resolved
+
+- name: Ensure resolvconf is not installed
+  ansible.builtin.package:
+    name:
+      - resolvconf
+    state: absent
+
+- name: Create /etc/resolv.conf symlink
+  ansible.builtin.file:
+    # If a file is already present at /etc/resolv.conf then just
+    # delete it.
+    force: true
+    group: root
+    mode: u=rw,g=r,o=r
+    owner: root
+    path: /etc/resolv.conf
+    src: /run/systemd/resolve/stub-resolv.conf
+    state: link
+
+- name: Enable systemd-resolved
+  ansible.builtin.service:
+    enabled: true
+    name: systemd-resolved.service


### PR DESCRIPTION
## 🗣 Description ##

This PR creates an Ansible role to install and configure `systemd-resolved`.

## 💭 Motivation and context ##

This PR contributes to the resolution of cisagov/cool-system-internal#140 since, once this role is applied to our COOL AMIs, they will use the `systemd-resolved` stub DNS resolver.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.