### PR TITLE
Support more configuration options

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,6 +176,7 @@ jobs:
       matrix:
         scenario:
           - default
+          - specify_resolv_conf_target
     steps:
       - id: harden-runner
         name: Harden the runner

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -176,6 +176,7 @@ jobs:
       matrix:
         scenario:
           - default
+          - disable_stub_resolver
           - specify_resolv_conf_target
     steps:
       - id: harden-runner

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -126,7 +126,7 @@ repos:
     hooks:
       - id: bandit
         # Bandit complains about the use of assert() in tests
-        exclude: molecule/(default|systemd_enabled)/tests
+        exclude: molecule/(default|specify_resolv_conf_target)/tests
         args:
           - --config=.bandit.yml
   - repo: https://github.com/psf/black-pre-commit-mirror

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -126,7 +126,7 @@ repos:
     hooks:
       - id: bandit
         # Bandit complains about the use of assert() in tests
-        exclude: molecule/(default|specify_resolv_conf_target)/tests
+        exclude: molecule/(default|disable_stub_resolver|specify_resolv_conf_target)/tests
         args:
           - --config=.bandit.yml
   - repo: https://github.com/psf/black-pre-commit-mirror

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ It performs the following actions:
 - Installs `systemd-resolved` and ensures that `resolvconf` is not
   installed.
 - Creates an `/etc/resolv.conf` symlink.
+- Optionally disables the `systemd-resolved` stub DNS resolver that
+  listens at `127.0.0.53`.
 
 ## Requirements ##
 
@@ -19,7 +21,8 @@ None.
 
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
-| systemd_resolved_resolv_conf_filename | The location of the target to which /etc/resolv.conf will be symlinked.  Note that `dynamic_resolv_conf_target_dir` and `static_resolv_conf_target_dir` are role vars that are available for use when defining this variable.  See [here](https://man.archlinux.org/man/systemd-resolved.8#/ETC/RESOLV.CONF) for more information. | `"{{ dynamic_resolv_conf_target_dir }}/stub-resolv.conf"` | No |
+| systemd_resolved_dns_stub_listener | The value to use for the DNSStubListener value in the `systemd-resolved` configuration file.  Must be `tcp`, `udp`, or a boolean value.  See [here](https://man.archlinux.org/man/resolved.conf.5.en) for more information. | `"yes"` | No |
+| systemd_resolved_resolv_conf_filename | The location of the target to which `/etc/resolv.conf` will be symlinked.  Note that `dynamic_resolv_conf_target_dir` and `static_resolv_conf_target_dir` are role vars that are available for use when defining this variable.  See [here](https://man.archlinux.org/man/systemd-resolved.8#/ETC/RESOLV.CONF) for more information. | `"{{ dynamic_resolv_conf_target_dir }}/stub-resolv.conf"` | No |
 <!--
 | required_variable | Describe its purpose. | n/a | Yes |
 -->

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ None.
 
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
-| systemd_resolved_dns_stub_listener | The value to use for the DNSStubListener value in the `systemd-resolved` configuration file.  Must be `tcp`, `udp`, or a boolean value.  See [here](https://man.archlinux.org/man/resolved.conf.5.en) for more information. | `"yes"` | No |
+| systemd_resolved_dns_stub_listener | The value to use for the DNSStubListener value in the `systemd-resolved` configuration file.  Must be `tcp`, `udp`, or a boolean value.  See [here](https://man.archlinux.org/man/resolved.conf.5.en) for more information. | `true` | No |
 | systemd_resolved_resolv_conf_filename | The location of the target to which `/etc/resolv.conf` will be symlinked.  Note that `dynamic_resolv_conf_target_dir` and `static_resolv_conf_target_dir` are role vars that are available for use when defining this variable.  See [here](https://man.archlinux.org/man/systemd-resolved.8#/ETC/RESOLV.CONF) for more information. | `"{{ dynamic_resolv_conf_target_dir }}/stub-resolv.conf"` | No |
 <!--
 | required_variable | Describe its purpose. | n/a | Yes |

--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@ It performs the following actions:
 
 - Installs `systemd-resolved` and ensures that `resolvconf` is not
   installed.
-- Creates an `/etc/resolv.conf` symlink that results in the
-  `systemd-resolved` stub DNS resolver being used by default for all
-  system DNS lookups.
+- Creates an `/etc/resolv.conf` symlink.
 
 ## Requirements ##
 
@@ -19,12 +17,10 @@ None.
 
 ## Role Variables ##
 
-None.
-
-<!--
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
-| optional_variable | Describe its purpose. | `default_value` | No |
+| systemd_resolved_resolv_conf_filename | The location of the target to which /etc/resolv.conf will be symlinked.  Note that `dynamic_resolv_conf_target_dir` and `static_resolv_conf_target_dir` are role vars that are available for use when defining this variable.  See [here](https://man.archlinux.org/man/systemd-resolved.8#/ETC/RESOLV.CONF) for more information. | `"{{ dynamic_resolv_conf_target_dir }}/stub-resolv.conf"` | No |
+<!--
 | required_variable | Describe its purpose. | n/a | Yes |
 -->
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,0 +1,17 @@
+---
+# The location of the file to which /etc/resolv.conf will be
+# symlinked.  The symlink target should normally be one of the
+# following files provided by systemd-resolved:
+# 1. "{{ dynamic_resolv_conf_target_dir }}/stub-resolv.conf"
+# 2. "{{ dynamic_resolv_conf_target_dir }}/resolv.conf"
+# 3. "{{ static_resolv_conf_target_dir }}/resolv.conf"
+#
+# Note that the values of dynamic_resolv_conf_target_dir and
+# static_resolv_conf_target_dir come from the role vars.
+#
+# In most cases you will want to use option 1 when using the
+# systemd-resolved stub DNS resolver (127.0.0.53) and option 2 when
+# using the DNS resolver provided via DHCP.  See here for more
+# information:
+# https://man.archlinux.org/man/systemd-resolved.8#/ETC/RESOLV.CONF
+systemd_resolved_resolv_conf_filename: "{{ dynamic_resolv_conf_target_dir }}/stub-resolv.conf"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,12 @@
 ---
+# The value to use for the DNSStubListener value in the
+# systemd-resolved configuration file.  Must be tcp, udp, or a boolean
+# value.
+#
+# See here for more information:
+# https://man.archlinux.org/man/resolved.conf.5.en
+systemd_resolved_dns_stub_listener: true
+
 # The location of the file to which /etc/resolv.conf will be
 # symlinked.  The symlink target should normally be one of the
 # following files provided by systemd-resolved:

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -10,13 +10,14 @@
 - name: Unmount /etc/resolv.conf
   ansible.builtin.import_playbook: unmount.yml
 
-# We require dig for one of our Molecule tests
+# We require dig and netstat for our Molecule tests
 - name: Install dig
   hosts: all
   become: true
   become_method: ansible.builtin.sudo
   tasks:
-  - name: Install dig
+  - name: Install some tools that are required for testing
     ansible.builtin.package:
       name:
         - dnsutils
+        - net-tools

--- a/molecule/default/tests/test_default_basic.py
+++ b/molecule/default/tests/test_default_basic.py
@@ -1,0 +1,35 @@
+"""Module containing the tests for the default scenario."""
+
+# Standard Python Libraries
+import os
+
+# Third-Party Libraries
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ["MOLECULE_INVENTORY_FILE"]
+).get_hosts("all")
+
+
+def test_packages(host):
+    """Verify that the expected packages are installed/uninstalled."""
+    assert host.package(
+        "systemd-resolved"
+    ).is_installed, "The package systemd-resolved is not installed."
+    assert not host.package(
+        "resolvconf"
+    ).is_installed, "The package resolvconf is installed."
+
+
+def test_services(host):
+    """Verify that the expected services are present."""
+    s = host.service("systemd-resolved")
+    # TODO - This assertion currently fails because of
+    # pytest-dev/pytest-testinfra#757.  Once
+    # pytest-dev/pytest-testinfra#754 has been merged and a new
+    # release is created the following line can be uncommented.
+    #
+    # See #3 for more details.
+    # assert s.exists, "systemd-resolved service does not exist."
+    assert s.is_enabled, "systemd-resolved service is not enabled."
+    assert s.is_running, "systemd-resolved service is not running."

--- a/molecule/default/tests/test_default_specific.py
+++ b/molecule/default/tests/test_default_specific.py
@@ -54,4 +54,4 @@ def test_dns_resolution(host, dig_command):
         assert (
             re.search(r"^;; SERVER: 127\.0\.0\.53#53", cmd.stdout, re.MULTILINE)
             is not None
-        ), f"Command dig {dig_command} did not return a results from 127.0.0.53."
+        ), f"Command dig {dig_command} did not return a result from 127.0.0.53."

--- a/molecule/default/tests/test_default_specific.py
+++ b/molecule/default/tests/test_default_specific.py
@@ -13,16 +13,6 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 ).get_hosts("all")
 
 
-def test_packages(host):
-    """Verify that the expected packages are installed/uninstalled."""
-    assert host.package(
-        "systemd-resolved"
-    ).is_installed, "The package systemd-resolved is not installed."
-    assert not host.package(
-        "resolvconf"
-    ).is_installed, "The package resolvconf is installed."
-
-
 def test_symlink(host):
     """Verify that /etc/resolv.conf is the expected symlink."""
     f = host.file("/etc/resolv.conf")
@@ -39,20 +29,6 @@ def test_symlink(host):
     assert (
         f.linked_to == symlink_target
     ), f"/etc/resolv.conf is not a symlink to {symlink_target}."
-
-
-def test_services(host):
-    """Verify that the expected services are present."""
-    s = host.service("systemd-resolved")
-    # TODO - This assertion currently fails because of
-    # pytest-dev/pytest-testinfra#757.  Once
-    # pytest-dev/pytest-testinfra#754 has been merged and a new
-    # release is created the following line can be uncommented.
-    #
-    # See #3 for more details.
-    # assert s.exists, "systemd-resolved service does not exist."
-    assert s.is_enabled, "systemd-resolved service is not enabled."
-    assert s.is_running, "systemd-resolved service is not running."
 
 
 @pytest.mark.parametrize(

--- a/molecule/disable_stub_resolver/INSTALL.rst
+++ b/molecule/disable_stub_resolver/INSTALL.rst
@@ -1,0 +1,1 @@
+../default/INSTALL.rst

--- a/molecule/disable_stub_resolver/converge.yml
+++ b/molecule/disable_stub_resolver/converge.yml
@@ -1,0 +1,9 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: Include ansible-role-systemd-resolved
+      ansible.builtin.include_role:
+        name: ansible-role-systemd-resolved
+      vars:
+        systemd_resolved_dns_stub_listener: false

--- a/molecule/disable_stub_resolver/molecule.yml
+++ b/molecule/disable_stub_resolver/molecule.yml
@@ -1,0 +1,102 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-amazonlinux2023-ansible:latest
+    name: amazonlinux2023-systemd
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  # These platforms do not provide systemd-resolved.
+  # - cgroupns_mode: host
+  #   command: /lib/systemd/systemd
+  #   image: docker.io/geerlingguy/docker-debian10-ansible:latest
+  #   name: debian10-systemd
+  #   platform: amd64
+  #   pre_build_image: true
+  #   privileged: true
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  # - cgroupns_mode: host
+  #   command: /lib/systemd/systemd
+  #   image: docker.io/geerlingguy/docker-debian11-ansible:latest
+  #   name: debian11-systemd
+  #   platform: amd64
+  #   pre_build_image: true
+  #   privileged: true
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-debian12-ansible:latest
+    name: debian12-systemd
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/cisagov/docker-debian13-ansible:latest
+    name: debian13-systemd
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/cisagov/docker-kali-ansible:latest
+    name: kali-systemd
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-fedora38-ansible:latest
+    name: fedora38-systemd
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-fedora39-ansible:latest
+    name: fedora39-systemd
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  # These platforms do not provide systemd-resolved.
+  # - cgroupns_mode: host
+  #   command: /lib/systemd/systemd
+  #   image: docker.io/geerlingguy/docker-ubuntu2004-ansible:latest
+  #   name: ubuntu-20-systemd
+  #   platform: amd64
+  #   pre_build_image: true
+  #   privileged: true
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  # - cgroupns_mode: host
+  #   command: /lib/systemd/systemd
+  #   image: docker.io/geerlingguy/docker-ubuntu2204-ansible:latest
+  #   name: ubuntu-22-systemd
+  #   platform: amd64
+  #   pre_build_image: true
+  #   privileged: true
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+scenario:
+  name: disable_stub_resolver
+verifier:
+  name: testinfra

--- a/molecule/disable_stub_resolver/prepare.yml
+++ b/molecule/disable_stub_resolver/prepare.yml
@@ -1,0 +1,1 @@
+../default/prepare.yml

--- a/molecule/disable_stub_resolver/requirements.yml
+++ b/molecule/disable_stub_resolver/requirements.yml
@@ -1,0 +1,1 @@
+../default/requirements.yml

--- a/molecule/disable_stub_resolver/tests/test_default_basic.py
+++ b/molecule/disable_stub_resolver/tests/test_default_basic.py
@@ -1,0 +1,1 @@
+../../default/tests/test_default_basic.py

--- a/molecule/disable_stub_resolver/tests/test_disable_stub_resolver.py
+++ b/molecule/disable_stub_resolver/tests/test_disable_stub_resolver.py
@@ -1,4 +1,4 @@
-"""Module containing the tests for the default scenario."""
+"""Module containing the tests for the disable_stub_resolver scenario."""
 
 # Standard Python Libraries
 import os

--- a/molecule/disable_stub_resolver/tests/test_disable_stub_resolver.py
+++ b/molecule/disable_stub_resolver/tests/test_disable_stub_resolver.py
@@ -1,0 +1,29 @@
+"""Module containing the tests for the default scenario."""
+
+# Standard Python Libraries
+import os
+
+# Third-Party Libraries
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ["MOLECULE_INVENTORY_FILE"]
+).get_hosts("all")
+
+
+def test_port_53_listener(host):
+    """Verify that nothing is listening on port 53."""
+    # Have netstat output all TCP and UDP IPv4 listeners.
+    netstat_cmd = "netstat --protocol inet --listening --tcp --udp --numeric"
+    # Skip the first two lines of the output.
+    tail_cmd = "tail --lines +3"
+    # Grab only the 4th column.
+    awk_cmd = "awk '{print $4}'"
+    # Grab only the port.
+    cut_cmd = "cut --delimiter ':' --fields 2"
+    # Output the number of lines that contain only the number 53.
+    grep_cmd = 'grep --count "^53$"'
+    cmd = host.run(
+        f"test 0 -eq $({netstat_cmd} | {tail_cmd} | {awk_cmd} | {cut_cmd} | {grep_cmd})"
+    )
+    assert cmd.rc == 0, "Something is listening on port 53."

--- a/molecule/disable_stub_resolver/tests/test_disable_stub_resolver.py
+++ b/molecule/disable_stub_resolver/tests/test_disable_stub_resolver.py
@@ -14,7 +14,7 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 def test_port_53_listener(host):
     """Verify that nothing is listening on port 53."""
     # Have netstat output all TCP and UDP IPv4 listeners.
-    netstat_cmd = "netstat --protocol inet --listening --tcp --udp --numeric"
+    netstat_cmd = "netstat --protocol inet --listening --numeric --tcp --udp "
     # Skip the first two lines of the output.
     tail_cmd = "tail --lines +3"
     # Grab only the 4th column.

--- a/molecule/disable_stub_resolver/unmount.yml
+++ b/molecule/disable_stub_resolver/unmount.yml
@@ -1,0 +1,1 @@
+../default/unmount.yml

--- a/molecule/disable_stub_resolver/upgrade.yml
+++ b/molecule/disable_stub_resolver/upgrade.yml
@@ -1,0 +1,1 @@
+../default/upgrade.yml

--- a/molecule/specify_resolv_conf_target/INSTALL.rst
+++ b/molecule/specify_resolv_conf_target/INSTALL.rst
@@ -1,0 +1,1 @@
+../default/INSTALL.rst

--- a/molecule/specify_resolv_conf_target/converge.yml
+++ b/molecule/specify_resolv_conf_target/converge.yml
@@ -1,0 +1,9 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+    - name: Include ansible-role-systemd-resolved
+      ansible.builtin.include_role:
+        name: ansible-role-systemd-resolved
+      vars:
+        systemd_resolved_resolv_conf_filename: "{{ dynamic_resolv_conf_target_dir }}/resolv.conf"

--- a/molecule/specify_resolv_conf_target/molecule.yml
+++ b/molecule/specify_resolv_conf_target/molecule.yml
@@ -1,0 +1,102 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-amazonlinux2023-ansible:latest
+    name: amazonlinux2023-systemd
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  # These platforms do not provide systemd-resolved.
+  # - cgroupns_mode: host
+  #   command: /lib/systemd/systemd
+  #   image: docker.io/geerlingguy/docker-debian10-ansible:latest
+  #   name: debian10-systemd
+  #   platform: amd64
+  #   pre_build_image: true
+  #   privileged: true
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  # - cgroupns_mode: host
+  #   command: /lib/systemd/systemd
+  #   image: docker.io/geerlingguy/docker-debian11-ansible:latest
+  #   name: debian11-systemd
+  #   platform: amd64
+  #   pre_build_image: true
+  #   privileged: true
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-debian12-ansible:latest
+    name: debian12-systemd
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/cisagov/docker-debian13-ansible:latest
+    name: debian13-systemd
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/cisagov/docker-kali-ansible:latest
+    name: kali-systemd
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-fedora38-ansible:latest
+    name: fedora38-systemd
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-fedora39-ansible:latest
+    name: fedora39-systemd
+    platform: amd64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  # These platforms do not provide systemd-resolved.
+  # - cgroupns_mode: host
+  #   command: /lib/systemd/systemd
+  #   image: docker.io/geerlingguy/docker-ubuntu2004-ansible:latest
+  #   name: ubuntu-20-systemd
+  #   platform: amd64
+  #   pre_build_image: true
+  #   privileged: true
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  # - cgroupns_mode: host
+  #   command: /lib/systemd/systemd
+  #   image: docker.io/geerlingguy/docker-ubuntu2204-ansible:latest
+  #   name: ubuntu-22-systemd
+  #   platform: amd64
+  #   pre_build_image: true
+  #   privileged: true
+  #   volumes:
+  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+scenario:
+  name: specify_resolv_conf_target
+verifier:
+  name: testinfra

--- a/molecule/specify_resolv_conf_target/prepare.yml
+++ b/molecule/specify_resolv_conf_target/prepare.yml
@@ -1,0 +1,1 @@
+../default/prepare.yml

--- a/molecule/specify_resolv_conf_target/requirements.yml
+++ b/molecule/specify_resolv_conf_target/requirements.yml
@@ -1,0 +1,1 @@
+../default/requirements.yml

--- a/molecule/specify_resolv_conf_target/tests/test_default_basic.py
+++ b/molecule/specify_resolv_conf_target/tests/test_default_basic.py
@@ -1,0 +1,1 @@
+../../default/tests/test_default_basic.py

--- a/molecule/specify_resolv_conf_target/tests/test_specify_resolv_conf_target.py
+++ b/molecule/specify_resolv_conf_target/tests/test_specify_resolv_conf_target.py
@@ -1,4 +1,4 @@
-"""Module containing the tests for the default scenario."""
+"""Module containing the tests for the specify_resolv_conf_target scenario."""
 
 # Standard Python Libraries
 import os

--- a/molecule/specify_resolv_conf_target/tests/test_specify_resolv_conf_target.py
+++ b/molecule/specify_resolv_conf_target/tests/test_specify_resolv_conf_target.py
@@ -1,0 +1,45 @@
+"""Module containing the tests for the default scenario."""
+
+# Standard Python Libraries
+import os
+
+# Third-Party Libraries
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ["MOLECULE_INVENTORY_FILE"]
+).get_hosts("all")
+
+
+def test_symlink(host):
+    """Verify that /etc/resolv.conf is the expected symlink."""
+    f = host.file("/etc/resolv.conf")
+    assert f.is_symlink, "/etc/resolv.conf is not a symlink."
+
+    symlink_target = "/run/systemd/resolve/resolv.conf"
+
+    assert (
+        f.linked_to == symlink_target
+    ), f"/etc/resolv.conf is not a symlink to {symlink_target}."
+
+
+# Unfortunately this test does not function as expected, since Docker
+# containers normally just get a copy of their host's /etc/resolv.conf
+# and do not receive any DNS nameservers via DHCP.
+# @pytest.mark.parametrize(
+#     "dig_command",
+#     [
+#         "www.yahoo.com",
+#         "AAAA www.yahoo.com",
+#     ],
+# )
+# def test_dns_resolution(host, dig_command):
+#     """Verify that the systemd-resolved resolver is not being used by default."""
+#     cmd = host.run(f"dig {dig_command}")
+#     assert cmd.rc == 0, f"Command dig {dig_command} did not exit successfully."
+#     # Verify that the dig result came from the systemd-resolved
+#     # service.
+#     assert (
+#         re.search(r"^;; SERVER: 127\.0\.0\.53#53", cmd.stdout, re.MULTILINE)
+#         is None
+#     ), f"Command dig {dig_command} returned a result from 127.0.0.53."

--- a/molecule/specify_resolv_conf_target/unmount.yml
+++ b/molecule/specify_resolv_conf_target/unmount.yml
@@ -1,0 +1,1 @@
+../default/unmount.yml

--- a/molecule/specify_resolv_conf_target/upgrade.yml
+++ b/molecule/specify_resolv_conf_target/upgrade.yml
@@ -1,0 +1,1 @@
+../default/upgrade.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,20 @@
     name:
       - systemd-resolved
 
+- name: Set DNSStubListener in the systemd-resolved configuration file
+  community.general.ini_file:
+    # This config file should already exist, and putting false here
+    # allows us to avoid ansible-lint warnings about needing to
+    # specify the group, owner, and mode of the file.
+    create: false
+    # This is just to maintain the look and feel of the file as
+    # provided by systemd-resolved.
+    no_extra_spaces: true
+    option: DNSStubListener
+    path: /etc/systemd/resolved.conf
+    section: Resolve
+    value: "{{ systemd_resolved_dns_stub_listener }}"
+
 - name: Enable and start systemd-resolved
   ansible.builtin.service:
     enabled: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -42,7 +42,7 @@
     # provided by systemd-resolved.
     no_extra_spaces: true
     option: DNSStubListener
-    path: /etc/systemd/resolved.conf
+    path: "{{ config_file }}"
     section: Resolve
     value: "{{ systemd_resolved_dns_stub_listener }}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,20 @@
 ---
+- name: Verify role variables
+  block:
+    - name: Verify value of systemd_resolved_dns_stub_listener
+      ansible.builtin.assert:
+        fail_msg: >
+          Invalid value for systemd_resolved_dns_stub_listener: {{
+          systemd_resolved_dns_stub_listener }}.  Valid values are the
+          strings tcp or udp, or a boolean value.
+        # True if any of the elements of conditions is true
+        that: conditions is any
+      vars:
+        conditions:
+          - systemd_resolved_dns_stub_listener is boolean
+          - systemd_resolved_dns_stub_listener is string and systemd_resolved_dns_stub_listener == "tcp"
+          - systemd_resolved_dns_stub_listener is string and systemd_resolved_dns_stub_listener == "udp"
+
 - name: Load var file with package names based on the OS type
   ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
   vars:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
           - systemd_resolved_dns_stub_listener is string and systemd_resolved_dns_stub_listener == "tcp"
           - systemd_resolved_dns_stub_listener is string and systemd_resolved_dns_stub_listener == "udp"
 
-- name: Load var file with package names based on the OS type
+- name: Load var file with OS-specific information
   ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
   vars:
     params:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,16 @@
 ---
+- name: Load var file with package names based on the OS type
+  ansible.builtin.include_vars: "{{ lookup('first_found', params) }}"
+  vars:
+    params:
+      files:
+        - "{{ ansible_distribution }}_{{ ansible_distribution_release }}.yml"
+        - "{{ ansible_distribution }}.yml"
+        - "{{ ansible_os_family }}.yml"
+        - default.yml
+      paths:
+        - "{{ role_path }}/vars"
+
 - name: Install systemd-resolved
   ansible.builtin.package:
     name:
@@ -41,5 +53,5 @@
     # delete it.
     force: true
     path: /etc/resolv.conf
-    src: /run/systemd/resolve/stub-resolv.conf
+    src: "{{ systemd_resolved_resolv_conf_filename }}"
     state: link

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -1,0 +1,7 @@
+---
+# The directory where systemd-resolved stores the _dynamic_
+# resolv.conf symlink targets it provides.
+dynamic_resolv_conf_target_dir: /run/systemd/resolve
+# The directory where systemd-resolved stores the _static_ resolv.conf
+# symlink targets it provides.
+static_resolv_conf_target_dir: /usr/lib/systemd

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -1,4 +1,7 @@
 ---
+# The location of the systemd-resolved configuration file.
+config_file: /etc/systemd/resolved.conf
+
 # The directory where systemd-resolved stores the _dynamic_
 # resolv.conf symlink targets it provides.
 dynamic_resolv_conf_target_dir: /run/systemd/resolve


### PR DESCRIPTION
## 🗣 Description ##

This pull request adds the ability to:
- Specify the target to which `/etc/resolv.conf` will be symlinked.
- Specify that the `systemd-resolved` DNS stub resolver be disabled.

## 💭 Motivation and context ##

Resolves #2.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

- [x] Add `build / test (disable_stub_resolver)` and `build / test (specify_resolv_conf_target)` checks as required.