### PR TITLE
Write a config drop-in instead of modifying the systemd-provided config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ None.
 | Variable | Description | Default | Required |
 |----------|-------------|---------|----------|
 | systemd_resolved_dns_stub_listener | The value to use for the DNSStubListener value in the `systemd-resolved` configuration file.  Must be `tcp`, `udp`, or a boolean value.  See [here](https://man.archlinux.org/man/resolved.conf.5.en) for more information. | `true` | No |
+| systemd_resolved_dropin_config_file | The location of the systemd-resolved drop-in configuration file that will be created. | `/etc/systemd/resolved.conf.d/99-ansible-role-systemd-resolved` | No |
 | systemd_resolved_resolv_conf_filename | The location of the target to which `/etc/resolv.conf` will be symlinked.  Note that `dynamic_resolv_conf_target_dir` and `static_resolv_conf_target_dir` are role vars that are available for use when defining this variable.  See [here](https://man.archlinux.org/man/systemd-resolved.8#/ETC/RESOLV.CONF) for more information. | `"{{ dynamic_resolv_conf_target_dir }}/stub-resolv.conf"` | No |
 <!--
 | required_variable | Describe its purpose. | n/a | Yes |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,10 @@
 # https://man.archlinux.org/man/resolved.conf.5.en
 systemd_resolved_dns_stub_listener: true
 
+# The location of the systemd-resolved drop-in configuration file that
+# will be created.
+systemd_resolved_dropin_config_file: /etc/systemd/resolved.conf.d/99-ansible-role-systemd-resolved.conf
+
 # The location of the file to which /etc/resolv.conf will be
 # symlinked.  The symlink target should normally be one of the
 # following files provided by systemd-resolved:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,17 +32,26 @@
     name:
       - systemd-resolved
 
-- name: Set DNSStubListener in the systemd-resolved configuration file
+- name: >-
+    Ensure that the directory where the systemd-resolved drop-in will
+    live actually exists
+  ansible.builtin.file:
+    group: root
+    mode: 0755
+    owner: root
+    path: "{{ systemd_resolved_dropin_config_file | dirname }}"
+    state: directory
+
+- name: Set DNSStubListener config value for systemd-resolved
   community.general.ini_file:
-    # This config file should already exist, and putting false here
-    # allows us to avoid ansible-lint warnings about needing to
-    # specify the group, owner, and mode of the file.
-    create: false
-    # This is just to maintain the look and feel of the file as
-    # provided by systemd-resolved.
+    group: root
+    mode: 0644
+    # This is just to maintain the look and feel of the
+    # /etc/systemd/resolved.conf file as provided by systemd-resolved.
     no_extra_spaces: true
     option: DNSStubListener
-    path: "{{ config_file }}"
+    owner: root
+    path: "{{ systemd_resolved_dropin_config_file }}"
     section: Resolve
     value: "{{ systemd_resolved_dns_stub_listener }}"
 

--- a/vars/default.yml
+++ b/vars/default.yml
@@ -1,7 +1,4 @@
 ---
-# The location of the systemd-resolved configuration file.
-config_file: /etc/systemd/resolved.conf
-
 # The directory where systemd-resolved stores the _dynamic_
 # resolv.conf symlink targets it provides.
 dynamic_resolv_conf_target_dir: /run/systemd/resolve


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Ansible code to write a config drop-ins instead of modifying the `systemd-provided` config file.

## 💭 Motivation and context ##

This is the method that is preferred in [the documentation](https://man.archlinux.org/man/resolved.conf.5.en#CONFIGURATION_DIRECTORIES_AND_PRECEDENCE).

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] All new and existing tests pass.