### PR TITLE
Uncomment assertion

### DIFF
--- a/molecule/default/tests/test_default_basic.py
+++ b/molecule/default/tests/test_default_basic.py
@@ -24,12 +24,6 @@ def test_packages(host):
 def test_services(host):
     """Verify that the expected services are present."""
     s = host.service("systemd-resolved")
-    # TODO - This assertion currently fails because of
-    # pytest-dev/pytest-testinfra#757.  Once
-    # pytest-dev/pytest-testinfra#754 has been merged and a new
-    # release is created the following line can be uncommented.
-    #
-    # See #3 for more details.
-    # assert s.exists, "systemd-resolved service does not exist."
+    assert s.exists, "systemd-resolved service does not exist."
     assert s.is_enabled, "systemd-resolved service is not enabled."
     assert s.is_running, "systemd-resolved service is not running."

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -30,4 +30,6 @@ ansible-core>=2.16.7
 molecule>=5.0.1
 molecule-plugins[docker]
 pre-commit
-pytest-testinfra
+# pytest-testinfra contains a fix for SystemdService.exists that is
+# required by this role's Molecule test code.
+pytest-testinfra>=10.1.1


### PR DESCRIPTION
## 🗣 Description ##

This pull request uncomments an assertion in test code.

## 💭 Motivation and context ##

Resolves #3.

The assertion was previously commented out because of pytest-dev/pytest-testinfra#757.  This issue was remedied in pytest-dev/pytest-testinfra#767, and that pull request has been merged and [released in version 10.1.1](https://github.com/pytest-dev/pytest-testinfra/releases/tag/10.1.1).

See also:
- pytest-dev/pytest-testinfra#757
- pytest-dev/pytest-testinfra#767

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.