### PR TITLE
Cease excluding ARM64 platforms from Molecule testing where possible

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,26 +184,6 @@ jobs:
         architecture:
           - amd64
           - arm64
-        exclude:
-            # TODO: Starting with systemd version 253 or 254 (I'm not
-            # sure which) it is no longer possible to start
-            # systemd-resolved.service under QEMU emulation.  We
-            # support this case, but we cannot test it until we have
-            # native ARM64 runners.
-            #
-            # See issue #10 for more details.
-            - architecture: arm64
-              platform: debian13-systemd
-            - architecture: arm64
-              platform: fedora39-systemd
-            - architecture: arm64
-              platform: fedora40-systemd
-            - architecture: arm64
-              platform: fedora41-systemd
-            - architecture: arm64
-              platform: kali-systemd
-            - architecture: arm64
-              platform: ubuntu-24-systemd
         platform:
           - amazonlinux2023-systemd
           # These platforms do not provide systemd-resolved.

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -86,21 +86,15 @@ platforms:
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  # TODO: Starting with systemd version 253 or 254 (I'm not sure
-  # which) it is no longer possible to start systemd-resolved.service
-  # under QEMU emulation.  We support this case, but we cannot test it
-  # until we have native ARM64 runners.
-  #
-  # See issue #10 for more details.
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: docker.io/cisagov/docker-debian13-ansible:latest
-  #   name: debian13-systemd-arm64
-  #   platform: arm64
-  #   pre_build_image: true
-  #   privileged: true
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/cisagov/docker-debian13-ansible:latest
+    name: debian13-systemd-arm64
+    platform: arm64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/cisagov/docker-kali-ansible:latest
@@ -110,21 +104,15 @@ platforms:
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  # TODO: Starting with systemd version 253 or 254 (I'm not sure
-  # which) it is no longer possible to start systemd-resolved.service
-  # under QEMU emulation.  We support this case, but we cannot test it
-  # until we have native ARM64 runners.
-  #
-  # See issue #10 for more details.
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: docker.io/cisagov/docker-kali-ansible:latest
-  #   name: kali-systemd-arm64
-  #   platform: arm64
-  #   pre_build_image: true
-  #   privileged: true
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/cisagov/docker-kali-ansible:latest
+    name: kali-systemd-arm64
+    platform: arm64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-fedora39-ansible:latest
@@ -134,21 +122,15 @@ platforms:
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  # TODO: Starting with systemd version 253 or 254 (I'm not sure
-  # which) it is no longer possible to start systemd-resolved.service
-  # under QEMU emulation.  We support this case, but we cannot test it
-  # until we have native ARM64 runners.
-  #
-  # See issue #10 for more details.
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: docker.io/geerlingguy/docker-fedora39-ansible:latest
-  #   name: fedora39-systemd-arm64
-  #   platform: arm64
-  #   pre_build_image: true
-  #   privileged: true
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-fedora39-ansible:latest
+    name: fedora39-systemd-arm64
+    platform: arm64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-fedora40-ansible:latest
@@ -158,21 +140,15 @@ platforms:
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  # TODO: Starting with systemd version 253 or 254 (I'm not sure
-  # which) it is no longer possible to start systemd-resolved.service
-  # under QEMU emulation.  We support this case, but we cannot test it
-  # until we have native ARM64 runners.
-  #
-  # See issue #10 for more details.
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: docker.io/geerlingguy/docker-fedora40-ansible:latest
-  #   name: fedora40-systemd-arm64
-  #   platform: arm64
-  #   pre_build_image: true
-  #   privileged: true
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-fedora40-ansible:latest
+    name: fedora40-systemd-arm64
+    platform: arm64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-fedora41-ansible:latest
@@ -182,21 +158,15 @@ platforms:
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  # TODO: Starting with systemd version 253 or 254 (I'm not sure
-  # which) it is no longer possible to start systemd-resolved.service
-  # under QEMU emulation.  We support this case, but we cannot test it
-  # until we have native ARM64 runners.
-  #
-  # See issue #10 for more details.
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: docker.io/geerlingguy/docker-fedora41-ansible:latest
-  #   name: fedora41-systemd-arm64
-  #   platform: arm64
-  #   pre_build_image: true
-  #   privileged: true
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-fedora41-ansible:latest
+    name: fedora41-systemd-arm64
+    platform: arm64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
   # These platforms do not provide systemd-resolved.
   # - cgroupns_mode: host
   #   command: /lib/systemd/systemd
@@ -243,21 +213,15 @@ platforms:
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  # TODO: Starting with systemd version 253 or 254 (I'm not sure
-  # which) it is no longer possible to start systemd-resolved.service
-  # under QEMU emulation.  We support this case, but we cannot test it
-  # until we have native ARM64 runners.
-  #
-  # See issue #10 for more details.
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: docker.io/geerlingguy/docker-ubuntu2404-ansible:latest
-  #   name: ubuntu-24-systemd-arm64
-  #   platform: arm64
-  #   pre_build_image: true
-  #   privileged: true
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-ubuntu2404-ansible:latest
+    name: ubuntu-24-systemd-arm64
+    platform: arm64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
 scenario:
   name: default
 verifier:

--- a/molecule/disable_stub_resolver/molecule.yml
+++ b/molecule/disable_stub_resolver/molecule.yml
@@ -86,21 +86,15 @@ platforms:
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  # TODO: Starting with systemd version 253 or 254 (I'm not sure
-  # which) it is no longer possible to start systemd-resolved.service
-  # under QEMU emulation.  We support this case, but we cannot test it
-  # until we have native ARM64 runners.
-  #
-  # See issue #10 for more details.
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: docker.io/cisagov/docker-debian13-ansible:latest
-  #   name: debian13-systemd-arm64
-  #   platform: arm64
-  #   pre_build_image: true
-  #   privileged: true
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/cisagov/docker-debian13-ansible:latest
+    name: debian13-systemd-arm64
+    platform: arm64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/cisagov/docker-kali-ansible:latest
@@ -110,21 +104,15 @@ platforms:
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  # TODO: Starting with systemd version 253 or 254 (I'm not sure
-  # which) it is no longer possible to start systemd-resolved.service
-  # under QEMU emulation.  We support this case, but we cannot test it
-  # until we have native ARM64 runners.
-  #
-  # See issue #10 for more details.
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: docker.io/cisagov/docker-kali-ansible:latest
-  #   name: kali-systemd-arm64
-  #   platform: arm64
-  #   pre_build_image: true
-  #   privileged: true
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/cisagov/docker-kali-ansible:latest
+    name: kali-systemd-arm64
+    platform: arm64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-fedora39-ansible:latest
@@ -134,21 +122,15 @@ platforms:
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  # TODO: Starting with systemd version 253 or 254 (I'm not sure
-  # which) it is no longer possible to start systemd-resolved.service
-  # under QEMU emulation.  We support this case, but we cannot test it
-  # until we have native ARM64 runners.
-  #
-  # See issue #10 for more details.
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: docker.io/geerlingguy/docker-fedora39-ansible:latest
-  #   name: fedora39-systemd-arm64
-  #   platform: arm64
-  #   pre_build_image: true
-  #   privileged: true
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-fedora39-ansible:latest
+    name: fedora39-systemd-arm64
+    platform: arm64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-fedora40-ansible:latest
@@ -158,21 +140,15 @@ platforms:
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  # TODO: Starting with systemd version 253 or 254 (I'm not sure
-  # which) it is no longer possible to start systemd-resolved.service
-  # under QEMU emulation.  We support this case, but we cannot test it
-  # until we have native ARM64 runners.
-  #
-  # See issue #10 for more details.
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: docker.io/geerlingguy/docker-fedora40-ansible:latest
-  #   name: fedora40-systemd-arm64
-  #   platform: arm64
-  #   pre_build_image: true
-  #   privileged: true
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-fedora40-ansible:latest
+    name: fedora40-systemd-arm64
+    platform: arm64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-fedora41-ansible:latest
@@ -182,21 +158,15 @@ platforms:
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  # TODO: Starting with systemd version 253 or 254 (I'm not sure
-  # which) it is no longer possible to start systemd-resolved.service
-  # under QEMU emulation.  We support this case, but we cannot test it
-  # until we have native ARM64 runners.
-  #
-  # See issue #10 for more details.
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: docker.io/geerlingguy/docker-fedora41-ansible:latest
-  #   name: fedora41-systemd-arm64
-  #   platform: arm64
-  #   pre_build_image: true
-  #   privileged: true
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-fedora41-ansible:latest
+    name: fedora41-systemd-arm64
+    platform: arm64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
   # These platforms do not provide systemd-resolved.
   # - cgroupns_mode: host
   #   command: /lib/systemd/systemd
@@ -243,21 +213,15 @@ platforms:
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  # TODO: Starting with systemd version 253 or 254 (I'm not sure
-  # which) it is no longer possible to start systemd-resolved.service
-  # under QEMU emulation.  We support this case, but we cannot test it
-  # until we have native ARM64 runners.
-  #
-  # See issue #10 for more details.
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: docker.io/geerlingguy/docker-ubuntu2404-ansible:latest
-  #   name: ubuntu-24-systemd-arm64
-  #   platform: arm64
-  #   pre_build_image: true
-  #   privileged: true
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-ubuntu2404-ansible:latest
+    name: ubuntu-24-systemd-arm64
+    platform: arm64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
 scenario:
   name: disable_stub_resolver
 verifier:

--- a/molecule/specify_resolv_conf_target/molecule.yml
+++ b/molecule/specify_resolv_conf_target/molecule.yml
@@ -86,21 +86,15 @@ platforms:
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  # TODO: Starting with systemd version 253 or 254 (I'm not sure
-  # which) it is no longer possible to start systemd-resolved.service
-  # under QEMU emulation.  We support this case, but we cannot test it
-  # until we have native ARM64 runners.
-  #
-  # See issue #10 for more details.
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: docker.io/cisagov/docker-debian13-ansible:latest
-  #   name: debian13-systemd-arm64
-  #   platform: arm64
-  #   pre_build_image: true
-  #   privileged: true
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/cisagov/docker-debian13-ansible:latest
+    name: debian13-systemd-arm64
+    platform: arm64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/cisagov/docker-kali-ansible:latest
@@ -110,21 +104,15 @@ platforms:
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  # TODO: Starting with systemd version 253 or 254 (I'm not sure
-  # which) it is no longer possible to start systemd-resolved.service
-  # under QEMU emulation.  We support this case, but we cannot test it
-  # until we have native ARM64 runners.
-  #
-  # See issue #10 for more details.
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: docker.io/cisagov/docker-kali-ansible:latest
-  #   name: kali-systemd-arm64
-  #   platform: arm64
-  #   pre_build_image: true
-  #   privileged: true
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/cisagov/docker-kali-ansible:latest
+    name: kali-systemd-arm64
+    platform: arm64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-fedora39-ansible:latest
@@ -134,21 +122,15 @@ platforms:
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  # TODO: Starting with systemd version 253 or 254 (I'm not sure
-  # which) it is no longer possible to start systemd-resolved.service
-  # under QEMU emulation.  We support this case, but we cannot test it
-  # until we have native ARM64 runners.
-  #
-  # See issue #10 for more details.
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: docker.io/geerlingguy/docker-fedora39-ansible:latest
-  #   name: fedora39-systemd-arm64
-  #   platform: arm64
-  #   pre_build_image: true
-  #   privileged: true
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-fedora39-ansible:latest
+    name: fedora39-systemd-arm64
+    platform: arm64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-fedora40-ansible:latest
@@ -158,21 +140,15 @@ platforms:
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  # TODO: Starting with systemd version 253 or 254 (I'm not sure
-  # which) it is no longer possible to start systemd-resolved.service
-  # under QEMU emulation.  We support this case, but we cannot test it
-  # until we have native ARM64 runners.
-  #
-  # See issue #10 for more details.
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: docker.io/geerlingguy/docker-fedora40-ansible:latest
-  #   name: fedora40-systemd-arm64
-  #   platform: arm64
-  #   pre_build_image: true
-  #   privileged: true
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-fedora40-ansible:latest
+    name: fedora40-systemd-arm64
+    platform: arm64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
   - cgroupns_mode: host
     command: /lib/systemd/systemd
     image: docker.io/geerlingguy/docker-fedora41-ansible:latest
@@ -182,21 +158,15 @@ platforms:
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  # TODO: Starting with systemd version 253 or 254 (I'm not sure
-  # which) it is no longer possible to start systemd-resolved.service
-  # under QEMU emulation.  We support this case, but we cannot test it
-  # until we have native ARM64 runners.
-  #
-  # See issue #10 for more details.
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: docker.io/geerlingguy/docker-fedora41-ansible:latest
-  #   name: fedora41-systemd-arm64
-  #   platform: arm64
-  #   pre_build_image: true
-  #   privileged: true
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-fedora41-ansible:latest
+    name: fedora41-systemd-arm64
+    platform: arm64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
   # These platforms do not provide systemd-resolved.
   # - cgroupns_mode: host
   #   command: /lib/systemd/systemd
@@ -243,21 +213,15 @@ platforms:
     privileged: true
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:rw
-  # TODO: Starting with systemd version 253 or 254 (I'm not sure
-  # which) it is no longer possible to start systemd-resolved.service
-  # under QEMU emulation.  We support this case, but we cannot test it
-  # until we have native ARM64 runners.
-  #
-  # See issue #10 for more details.
-  # - cgroupns_mode: host
-  #   command: /lib/systemd/systemd
-  #   image: docker.io/geerlingguy/docker-ubuntu2404-ansible:latest
-  #   name: ubuntu-24-systemd-arm64
-  #   platform: arm64
-  #   pre_build_image: true
-  #   privileged: true
-  #   volumes:
-  #     - /sys/fs/cgroup:/sys/fs/cgroup:rw
+  - cgroupns_mode: host
+    command: /lib/systemd/systemd
+    image: docker.io/geerlingguy/docker-ubuntu2404-ansible:latest
+    name: ubuntu-24-systemd-arm64
+    platform: arm64
+    pre_build_image: true
+    privileged: true
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
 scenario:
   name: specify_resolv_conf_target
 verifier:


### PR DESCRIPTION
## 🗣 Description ##

This pull request removes the exclusion of ARM64 platforms from Molecule testing where possible.

## 💭 Motivation and context ##

In many cases we no longer need to do this because we are now using native ARM64 GitHub Actions runners.

Resolves #10.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
